### PR TITLE
Resolve Git merge conflict in documentation

### DIFF
--- a/docs/plans/architecture/HIVE_PROFILE_CACHE_PLAN_Q3_2025.md
+++ b/docs/plans/architecture/HIVE_PROFILE_CACHE_PLAN_Q3_2025.md
@@ -20,13 +20,6 @@ Provide an encrypted offline cache for the user `Profile` entity using **Hive 4*
 ## 2  Task Breakdown
 | ID | Task | Owner | ETA |
 |----|------|-------|-----|
-| H1 | Add Hive deps (`hive`, `hive_flutter`) to `pubspec.yaml` | Dev | — |
-| H2 | Create `ProfileAdapter` + run codegen | Dev | — |
-| H3 | Implement `HiveProfileCache` (read/write helpers) | Dev | — |
-| H4 | Refactor `SupabaseProfileRepository` to inject optional cache & implement SW-R | Dev | — |
-| H5 | Unit tests with in-memory Hive (`Hive.initMemory()`) | QA | — |
-| H6 | Update docs (`ARCHITECTURE.md`) & diagrams | Tech writer | — | ✅ Done
-=======
 | H1 | Add Hive deps (`hive`, `hive_flutter`) to `pubspec.yaml` | Dev | ✅ Completed |
 | H2 | Create `ProfileAdapter` + run codegen | Dev | ✅ Completed |
 | H3 | Implement `HiveProfileCache` (read/write helpers) | Dev | ✅ Completed |


### PR DESCRIPTION
Remove unresolved Git merge conflict markers and duplicate content from `docs/plans/architecture/HIVE_PROFILE_CACHE_PLAN_Q3_2025.md`.

This fixes a bug where the file contained incomplete merge resolution artifacts, leading to duplicate task entries and rendering issues.