### PR TITLE
Analyze and fix static analysis issues

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,6 +12,10 @@ analyzer:
     - "build/**"
     - "test/**/*.mocks.dart"
     - "packages/test_utils/**"
+    # Ignore Flutter SDK dev tools & sample tests that are not part of this project
+    - "**/flutter*/dev/**"
+    - "**/flutter*/packages/**/test/**"
+    - "**/.pub-cache/**"
 
   language:
     strict-casts: true


### PR DESCRIPTION
Exclude Flutter SDK development and cache paths from static analysis to resolve 'Target of URI doesn't exist' errors.

The static analysis was reporting numerous 'Target of URI doesn't exist' and similar errors originating from internal Flutter SDK paths (e.g., `flutter_sdk/dev/a11y_assessments/test/`). These files are not part of the project's codebase and were causing noise in the analysis output, making it difficult to identify actual project-specific issues.