### PR TITLE
Fix build process errors and dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,3 +100,6 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+dependency_overrides:
+  analyzer: ^7.5.6

--- a/test/golden/field_diagram_toolbar_test.dart
+++ b/test/golden/field_diagram_toolbar_test.dart
@@ -38,45 +38,53 @@ void main() {
       resetScreenSizeBinding(binding);
     });
 
-    testWidgets('default (select) tool', (tester) async {
-      await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
-            home: Material(
-              child: FieldDiagramToolbar(
-                selectedTool: DiagramTool.select,
-                onToolSelected: _noop,
+    testWidgets(
+      'default (select) tool',
+      (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: Material(
+                child: FieldDiagramToolbar(
+                  selectedTool: DiagramTool.select,
+                  onToolSelected: _noop,
+                ),
               ),
             ),
           ),
-        ),
-      );
+        );
 
-      await expectLater(
-        find.byType(FieldDiagramToolbar),
-        matchesGoldenFile('goldens/field_diagram_toolbar_select.png'),
-      );
-    }, skip: isCi);
+        await expectLater(
+          find.byType(FieldDiagramToolbar),
+          matchesGoldenFile('goldens/field_diagram_toolbar_select.png'),
+        );
+      },
+      skip: isCi,
+    );
 
-    testWidgets('line tool expanded', (tester) async {
-      await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
-            home: Material(
-              child: FieldDiagramToolbar(
-                selectedTool: DiagramTool.line,
-                onToolSelected: _noop,
+    testWidgets(
+      'line tool expanded',
+      (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: Material(
+                child: FieldDiagramToolbar(
+                  selectedTool: DiagramTool.line,
+                  onToolSelected: _noop,
+                ),
               ),
             ),
           ),
-        ),
-      );
+        );
 
-      await expectLater(
-        find.byType(FieldDiagramToolbar),
-        matchesGoldenFile('goldens/field_diagram_toolbar_line.png'),
-      );
-    }, skip: isCi);
+        await expectLater(
+          find.byType(FieldDiagramToolbar),
+          matchesGoldenFile('goldens/field_diagram_toolbar_line.png'),
+        );
+      },
+      skip: isCi,
+    );
   });
 }
 


### PR DESCRIPTION
Fix build failure by reformatting test syntax and overriding `analyzer` version.

The build was failing due to "Expected to find '}'" errors reported by `hive_generator`. This was caused by an outdated `analyzer` version (3.1.0) not fully supporting the SDK's language version (3.8.0) when parsing specific `testWidgets` syntax (callback body and named parameter `skip:` on the same line). This PR reformats the problematic test code and explicitly overrides the `analyzer` version to ensure compatibility and correct parsing.