### PR TITLE
Fix hardcoded training number in PDFs

### DIFF
--- a/lib/data/supabase_training_data_source.dart
+++ b/lib/data/supabase_training_data_source.dart
@@ -60,6 +60,7 @@ class SupabaseTrainingDataSource {
       ..id = r['id'] as String? ?? ''
       ..date = DateTime.parse(r['date'] as String)
       ..duration = r['duration'] as int? ?? 0
+      ..trainingNumber = r['training_number'] as int?
       ..focus = _focus(r['focus'] as String?)
       ..intensity = _intensity(r['intensity'] as String?)
       ..status = _status(r['status'] as String?)
@@ -82,6 +83,7 @@ class SupabaseTrainingDataSource {
     'id': t.id,
     'date': t.date.toIso8601String(),
     'duration': t.duration,
+    'training_number': t.trainingNumber,
     'focus': t.focus.name,
     'intensity': t.intensity.name,
     'status': t.status.name,

--- a/lib/models/training.dart
+++ b/lib/models/training.dart
@@ -74,6 +74,11 @@ class Training {
   late DateTime date;
   late int duration; // in minutes
 
+  /// Sequential number of the training session within the season.
+  /// May be `null` when the value hasn't been assigned yet. Consumers
+  /// should fall back to `1` (or another sensible default) when `null`.
+  int? trainingNumber;
+
   @Enumerated(EnumType.name)
   late TrainingFocus focus;
 

--- a/lib/screens/training/training_attendance_screen.dart
+++ b/lib/screens/training/training_attendance_screen.dart
@@ -579,8 +579,8 @@ class _TrainingAttendanceScreenState
       TrainingSession.create(
         teamId: 'team',
         date: training.date,
-        // Use the actual training sequence number instead of always "1".
-        trainingNumber: trainingIndex + 1,
+        // Use the stored training number, falling back to 1 if not available.
+        trainingNumber: training.trainingNumber ?? 1,
       ),
       players,
     ));


### PR DESCRIPTION
Restore `training.trainingNumber` usage for PDF reports to fix incorrect training numbers.