### PR TITLE
Investigate and fix training edit screen error

### DIFF
--- a/lib/screens/training/training_edit_screen.dart
+++ b/lib/screens/training/training_edit_screen.dart
@@ -41,18 +41,31 @@ class _TrainingEditScreenState extends ConsumerState<TrainingEditScreen> {
     super.dispose();
   }
 
-  void _load() {
+  Future<void> _load() async {
+    // 1. Try to find the training in the already-loaded list (if any).
     final list = ref.read(trainingsProvider).value ?? [];
-    _training = list.firstWhere(
+    var training = list.firstWhere(
       (t) => t.id == widget.trainingId,
-      orElse: Training.new,
+      orElse: () => Training(),
     );
-    if (_training != null && _training!.id.isNotEmpty) {
-      _selectedDate = _training!.date;
-      _durationCtrl.text = _training!.duration.toString();
-      _focus = _training!.focus;
-      _intensity = _training!.intensity;
-      _status = _training!.status;
+
+    // 2. If not found, fetch it directly from the repository.
+    if (training.id.isEmpty) {
+      final repo = ref.read(trainingRepositoryProvider);
+      final res = await repo.getById(widget.trainingId);
+      training = res.dataOrNull ?? Training();
+    }
+
+    // 3. Populate the UI only when we have a valid training.
+    if (training.id.isNotEmpty && mounted) {
+      setState(() {
+        _training = training;
+        _selectedDate = training.date;
+        _durationCtrl.text = training.duration.toString();
+        _focus = training.focus;
+        _intensity = training.intensity;
+        _status = training.status;
+      });
     }
   }
 


### PR DESCRIPTION
Make `TrainingEditScreen`'s `_load()` method asynchronous to fetch training data directly, fixing a test failure where the form wasn't pre-filled.

The `TrainingEditScreen` previously assumed training data would always be available in the `trainingsProvider` cache. In test environments, this cache was often empty, causing the `_load()` method to fail to find the training and not pre-fill the form. This PR modifies `_load()` to first check the cache, and if the training is not found, it explicitly fetches it from the `trainingRepositoryProvider`, ensuring the screen correctly loads and displays the data.