### PR TITLE
Fix null coalescing operator issue

### DIFF
--- a/lib/screens/training/training_attendance_screen.dart
+++ b/lib/screens/training/training_attendance_screen.dart
@@ -571,11 +571,22 @@ class _TrainingAttendanceScreenState
 
     final players = ref.read(playersProvider).value ?? [];
     final generator = ref.read(trainingSessionPdfGeneratorProvider);
+    // Some older persisted Training documents may not have an initialised
+    // trainingNumber (added later in the data-model). Safely fall back to 1
+    // to avoid a LateInitializationError.
+    final trainingNumber = (() {
+      try {
+        return training.trainingNumber;
+      } catch (_) {
+        return 1;
+      }
+    })();
+
     final bytes = await generator.generate((
       TrainingSession.create(
         teamId: 'team',
         date: training.date,
-        trainingNumber: training.trainingNumber,
+        trainingNumber: trainingNumber,
       ),
       players,
     ));


### PR DESCRIPTION
Safely fall back to 1 for `training.trainingNumber` in PDF export to prevent `LateInitializationError` for older persisted `Training` objects.