### PR TITLE
Refine exception handling in catch block

### DIFF
--- a/lib/screens/training/training_attendance_screen.dart
+++ b/lib/screens/training/training_attendance_screen.dart
@@ -577,7 +577,10 @@ class _TrainingAttendanceScreenState
     final trainingNumber = (() {
       try {
         return training.trainingNumber;
-      } catch (_) {
+      } on LateInitializationError {
+        // If the trainingNumber field was never initialized (for older persisted
+        // Training documents), fall back to 1. Any other exception should
+        // propagate so that genuine issues aren t masked.
         return 1;
       }
     })();


### PR DESCRIPTION
Narrow `catch` block to `on LateInitializationError` to prevent masking other exceptions.