### PR TITLE
Fix CI monitor workflow file

### DIFF
--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -3,6 +3,7 @@ name: "🔎 CI Monitor"
 on:
   workflow_run:
     # Monitor all workflows in this repo; filter for completed events
+    workflows: ['**']
     types: [completed]
   schedule:
     # Daily check at 03:00 UTC to catch runs older than 90 days (optional extension point)


### PR DESCRIPTION
Fix `ci-monitor.yml` by adding `workflows: ['**']` to the `workflow_run` event, resolving the 'does not reference any workflows' error.