### PR TITLE
Fix training attendance FAB navigation

### DIFF
--- a/lib/screens/training/training_attendance_screen.dart
+++ b/lib/screens/training/training_attendance_screen.dart
@@ -104,8 +104,8 @@ class _TrainingAttendanceScreenState
           ? null
           : canManage
               ? FloatingActionButton(
-                  onPressed: () => context.go('/training/add'),
-                  child: const Icon(Icons.add),
+                  onPressed: () => context.go('/training/${widget.trainingId}/edit'),
+                  child: const Icon(Icons.edit),
                 )
               : null,
     );


### PR DESCRIPTION
Correct TrainingAttendanceScreen FAB to navigate to edit existing training and update icon, aligning with screen's purpose.