### PR TITLE
Fix github integration permissions for issue creation

### DIFF
--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     # Daily check at 03:00 UTC to catch runs older than 90 days (optional extension point)
     - cron: '0 3 * * *'
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   monitor:


### PR DESCRIPTION
Add `issues:write` permission to CI monitor workflow to fix 403 error.