### PR TITLE
Fix build and analysis errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Generate code (build_runner)
+        run: flutter pub run build_runner build --delete-conflicting-outputs
+
       - name: Melos bootstrap
         if: ${{ hashFiles('melos.yaml') != '' }}
         run: |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,12 @@ dependencies:
   # Networking
   http: ^0.13.6
 
+  # Added dependencies to fix missing imports
+  firebase_analytics: ^10.8.0
+  graphql_flutter: ^5.1.2
+  equatable: ^2.0.5
+  collection: ^1.18.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -97,6 +103,10 @@ dev_dependencies:
 
   # New dev dependency
   hive_test: ^1.0.1
+
+  # Added dev dependency for integration tests
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Add missing dependencies and a `build_runner` step to fix analysis errors and ensure code generation in CI.

The analysis errors indicated missing packages (`firebase_analytics`, `graphql_flutter`, `equatable`, `collection`, `integration_test`) and issues with generated files (`video_tag.g.dart`). Adding these dependencies to `pubspec.yaml` and including `flutter pub run build_runner build` in the CI workflow resolves these issues, allowing the project to build and analyze correctly.