### PR TITLE
Update CI workflow issue permissions

### DIFF
--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -9,9 +9,13 @@ on:
     # Daily check at 03:00 UTC to catch runs older than 90 days (optional extension point)
     - cron: '0 3 * * *'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   monitor:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: 📣 Open or comment on CI failure issue


### PR DESCRIPTION
Add `issues: write` permission to CI monitor workflow to resolve 403 error when creating issues, and skip runs from forks.