### PR TITLE
feat: load club data via service

### DIFF
--- a/lib/providers/club_provider.dart
+++ b/lib/providers/club_provider.dart
@@ -8,13 +8,19 @@ import '../models/club/staff_member.dart';
 import '../models/club/team.dart';
 import '../models/player.dart';
 import '../repositories/club_repository.dart';
+import '../services/club_service.dart';
 
 /// 🏆 Club Provider
 /// Manages club-level operations, teams, staff, and player progress
 class ClubProvider extends ChangeNotifier {
-  ClubProvider({required ClubRepository clubRepository})
-      : _clubRepository = clubRepository;
+  ClubProvider({
+    required ClubRepository clubRepository,
+    required ClubService clubService,
+  })  : _clubRepository = clubRepository,
+        _clubService = clubService;
+
   final ClubRepository _clubRepository;
+  final ClubService _clubService;
 
   // State
   Club? _currentClub;
@@ -118,18 +124,25 @@ class ClubProvider extends ChangeNotifier {
   // Team Management
   Future<void> _loadTeams() async {
     if (_currentClub == null) return;
-    // TODO(author): Implement when ClubService has getTeamsForClub method
-    // _teams = await _clubService.getTeamsForClub(_currentClub!.id);
-    notifyListeners();
+    try {
+      final loaded = await _clubService.getTeamsForClub(_currentClub!.id);
+      _teams
+        ..clear()
+        ..addAll(loaded);
+    } catch (e) {
+      _setError('Failed to load teams: $e');
+    } finally {
+      notifyListeners();
+    }
   }
 
   Future<void> addTeam(Team team) async {
     _setLoading(true);
     try {
-      // TODO(author): Implement when ClubService has createTeam method
-      // final newTeam = await _clubService.createTeam(team);
-      // _teams.add(newTeam);
+      final newTeam = await _clubService.createTeam(team);
+      _teams.add(newTeam);
       _clearError();
+      notifyListeners();
     } catch (e) {
       _setError('Failed to add team: $e');
     } finally {
@@ -140,23 +153,45 @@ class ClubProvider extends ChangeNotifier {
   // Data loading methods
   Future<void> _loadStaff() async {
     if (_currentClub == null) return;
-    // TODO(author): Implement when ClubService has getStaffForClub method
-    // _staff = await _clubService.getStaffForClub(_currentClub!.id);
-    notifyListeners();
+    try {
+      final loaded = await _clubService.getStaffForClub(_currentClub!.id);
+      _staff
+        ..clear()
+        ..addAll(loaded);
+    } catch (e) {
+      _setError('Failed to load staff: $e');
+    } finally {
+      notifyListeners();
+    }
   }
 
   Future<void> _loadAllPlayers() async {
     if (_currentClub == null) return;
-    // TODO(author): Implement when ClubService has getPlayersForClub method
-    // _allPlayers = await _clubService.getPlayersForClub(_currentClub!.id);
-    notifyListeners();
+    try {
+      final loaded = await _clubService.getPlayersForClub(_currentClub!.id);
+      _allPlayers
+        ..clear()
+        ..addAll(loaded);
+    } catch (e) {
+      _setError('Failed to load players: $e');
+    } finally {
+      notifyListeners();
+    }
   }
 
   Future<void> _loadPlayerProgress() async {
     if (_currentClub == null) return;
-    // TODO(author): Implement when ClubService has getPlayerProgressForClub method
-    // _playerProgress = await _clubService.getPlayerProgressForClub(_currentClub!.id);
-    notifyListeners();
+    try {
+      final loaded =
+          await _clubService.getPlayerProgressForClub(_currentClub!.id);
+      _playerProgress
+        ..clear()
+        ..addAll(loaded);
+    } catch (e) {
+      _setError('Failed to load player progress: $e');
+    } finally {
+      notifyListeners();
+    }
   }
 
   // Helper Methods

--- a/lib/services/club_service.dart
+++ b/lib/services/club_service.dart
@@ -60,6 +60,58 @@ class ClubService {
     return _clubs.values.toList();
   }
 
+  // Team Operations
+  Future<List<Team>> getTeamsForClub(String clubId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return _clubTeams[clubId]?.toList() ?? [];
+  }
+
+  Future<Team> createTeam(Team team) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    final teams = _clubTeams.putIfAbsent(team.clubId, () => []);
+    teams.add(team);
+    return team;
+  }
+
+  // Staff Operations
+  Future<List<StaffMember>> getStaffForClub(String clubId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return _clubStaff[clubId]?.toList() ?? [];
+  }
+
+  Future<StaffMember> addStaffMember(StaffMember staff) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    final staffList = _clubStaff.putIfAbsent(staff.clubId, () => []);
+    staffList.add(staff);
+    return staff;
+  }
+
+  // Player Operations
+  Future<List<Player>> getPlayersForClub(String clubId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return _clubPlayers[clubId]?.toList() ?? [];
+  }
+
+  Future<Player> addPlayer(Player player, String clubId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    final players = _clubPlayers.putIfAbsent(clubId, () => []);
+    players.add(player);
+    return player;
+  }
+
+  // Player Progress Operations
+  Future<List<PlayerProgress>> getPlayerProgressForClub(String clubId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return _clubProgress[clubId]?.toList() ?? [];
+  }
+
+  Future<PlayerProgress> addPlayerProgress(PlayerProgress progress) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    final progressList = _clubProgress.putIfAbsent(progress.clubId, () => []);
+    progressList.add(progress);
+    return progress;
+  }
+
   // Simplified demo data for testing
   Future<void> initializeDemoData() async {
     // Basic demo implementation would go here

--- a/test/providers/club_provider_test.dart
+++ b/test/providers/club_provider_test.dart
@@ -73,18 +73,19 @@ void main() {
     );
     await service.addStaffMember(staff);
 
-    final player = Player()
-      ..id = 'p1'
-      ..firstName = 'Alice'
-      ..lastName = 'Smith'
-      ..jerseyNumber = 9
-      ..birthDate = DateTime(2008, 1, 1)
-      ..position = Position.forward
-      ..preferredFoot = PreferredFoot.right
-      ..height = 170
-      ..weight = 60
-      ..createdAt = DateTime.now()
-      ..updatedAt = DateTime.now();
+    final player = Player(
+      id: 'p1',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      jerseyNumber: 9,
+      birthDate: DateTime(2008, 1, 1),
+      position: Position.forward,
+      preferredFoot: PreferredFoot.right,
+      height: 170,
+      weight: 60,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
     await service.addPlayer(player, club.id);
 
     final progress = PlayerProgress(

--- a/test/providers/club_provider_test.dart
+++ b/test/providers/club_provider_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jo17_tactical_manager/models/club/club.dart';
+import 'package:jo17_tactical_manager/models/club/player_progress.dart';
+import 'package:jo17_tactical_manager/models/club/staff_member.dart';
+import 'package:jo17_tactical_manager/models/club/team.dart';
+import 'package:jo17_tactical_manager/models/player.dart';
+import 'package:jo17_tactical_manager/providers/club_provider.dart';
+import 'package:jo17_tactical_manager/repositories/club_repository.dart';
+import 'package:jo17_tactical_manager/services/club_service.dart';
+import 'package:jo17_tactical_manager/core/result.dart';
+
+class _FakeClubRepository implements ClubRepository {
+  _FakeClubRepository(this._club);
+  final Club _club;
+
+  @override
+  Future<Result<void>> add(Club club) async => const Success(null);
+
+  @override
+  Future<Result<void>> delete(String id) async => const Success(null);
+
+  @override
+  Future<Result<List<Club>>> getAll() async => Success([_club]);
+
+  @override
+  Future<Result<Club?>> getById(String id) async => Success(_club);
+
+  @override
+  Future<Result<void>> update(Club club) async => const Success(null);
+}
+
+void main() {
+  test('loadClub loads teams, staff, players, and progress', () async {
+    final service = ClubService();
+
+    final club = Club(
+      id: 'c1',
+      name: 'Test Club',
+      shortName: 'TC',
+      foundedDate: DateTime(2020, 1, 1),
+      settings: const ClubSettings(),
+      status: ClubStatus.active,
+      createdAt: DateTime.now(),
+    );
+    await service.createClub(club);
+
+    final team = Team(
+      id: 't1',
+      clubId: club.id,
+      name: 'Team A',
+      shortName: 'TA',
+      ageCategory: AgeCategory.jo15,
+      level: TeamLevel.recreational,
+      gender: TeamGender.male,
+      currentSeason: '2024',
+      settings: const TeamSettings(),
+      status: TeamStatus.active,
+      createdAt: DateTime.now(),
+    );
+    await service.createTeam(team);
+
+    final staff = StaffMember(
+      id: 's1',
+      clubId: club.id,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@example.com',
+      primaryRole: StaffRole.headCoach,
+      permissions: const StaffPermissions(),
+      availability: const StaffAvailability(),
+      status: StaffStatus.active,
+      createdAt: DateTime.now(),
+    );
+    await service.addStaffMember(staff);
+
+    final player = Player()
+      ..id = 'p1'
+      ..firstName = 'Alice'
+      ..lastName = 'Smith'
+      ..jerseyNumber = 9
+      ..birthDate = DateTime(2008, 1, 1)
+      ..position = Position.forward
+      ..preferredFoot = PreferredFoot.right
+      ..height = 170
+      ..weight = 60
+      ..createdAt = DateTime.now()
+      ..updatedAt = DateTime.now();
+    await service.addPlayer(player, club.id);
+
+    final progress = PlayerProgress(
+      id: 'pr1',
+      playerId: player.id,
+      teamId: team.id,
+      clubId: club.id,
+      season: '2024',
+      startDate: DateTime.now(),
+      technicalSkills: const TechnicalSkills(),
+      physicalAttributes: const PhysicalAttributes(),
+      tacticalSkills: const TacticalSkills(),
+      mentalAttributes: const MentalAttributes(),
+      performanceMetrics: const PerformanceMetrics(),
+      overallRating: const OverallRating(),
+      status: ProgressStatus.active,
+      createdAt: DateTime.now(),
+    );
+    await service.addPlayerProgress(progress);
+
+    final repo = _FakeClubRepository(club);
+    final provider = ClubProvider(
+      clubRepository: repo,
+      clubService: service,
+    );
+
+    await provider.loadClub(club.id);
+
+    expect(provider.teams, [team]);
+    expect(provider.staff, [staff]);
+    expect(provider.allPlayers, [player]);
+    expect(provider.playerProgress, [progress]);
+  });
+}


### PR DESCRIPTION
## Summary
- wire `ClubProvider` to `ClubService` and load teams, staff, players and progress
- expand `ClubService` with CRUD helpers for teams, staff, players and progress
- add unit test covering club data loading

## Testing
- `flutter test test/providers/club_provider_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1665df700832aa757a7cd5ed2b4b6