### PR TITLE
feat: add deep link handling

### DIFF
--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -1,9 +1,61 @@
 // ignore_for_file: flutter_style_todos
+
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+import 'package:go_router/go_router.dart';
+
 class DeepLinkService {
   static final DeepLinkService instance = DeepLinkService();
 
-  Future<void> init(dynamic router) async {
-    // TODO(team): setup deep link handling using GoRouter instance.
+  StreamSubscription<Uri>? _linkSub;
+
+  /// Sets up deep link handling using the provided [GoRouter] instance.
+  ///
+  /// On mobile we listen to the [AppLinks] stream for incoming links and
+  /// process the initial link. On web we parse [Uri.base] once during
+  /// initialisation which covers refreshes and direct navigations.
+  Future<void> init(GoRouter router) async {
+    if (kIsWeb) {
+      _handleUri(router, Uri.base);
+      return;
+    }
+
+    final appLinks = AppLinks();
+
+    try {
+      final initial = await appLinks.getInitialLink();
+      _handleUri(router, initial);
+    } catch (_) {
+      // Ignore errors from the platform link handler.
+    }
+
+    _linkSub = appLinks.uriLinkStream.listen(
+      (uri) => _handleUri(router, uri),
+      onError: (_) {},
+    );
+  }
+
+  /// Exposed for unit testing.
+  @visibleForTesting
+  void handleUriForTest(Uri? uri, GoRouter router) => _handleUri(router, uri);
+
+  void _handleUri(GoRouter router, Uri? uri) {
+    if (uri == null) return;
+
+    // On web links are provided as hash fragments (e.g. #/matches/123).
+    final path = uri.fragment.isNotEmpty ? uri.fragment : uri.path;
+    final segments = Uri.parse(path).pathSegments;
+    if (segments.length < 2) return;
+
+    final id = segments[1];
+    switch (segments.first) {
+      case 'matches':
+        router.go('/matches/$id');
+      case 'training':
+        router.go('/training/$id');
+    }
   }
 
   /// Returns a shareable deep link for a match.

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -46,7 +46,7 @@ class DeepLinkService {
 
     // On web links are provided as hash fragments (e.g. #/matches/123).
     final path = uri.fragment.isNotEmpty ? uri.fragment : uri.path;
-    final segments = Uri.parse(path).pathSegments;
+    final segments = Uri(path: path).pathSegments;
     if (segments.length < 2) return;
 
     final id = segments[1];

--- a/test/services/deep_link_service_test.dart
+++ b/test/services/deep_link_service_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:jo17_tactical_manager/services/deep_link_service.dart';
+
+class _MockGoRouter extends Mock implements GoRouter {}
+
+void main() {
+  group('DeepLinkService.handleUriForTest', () {
+    late DeepLinkService service;
+    late _MockGoRouter router;
+
+    setUp(() {
+      service = DeepLinkService();
+      router = _MockGoRouter();
+    });
+
+    test('navigates to match route from web hash URI', () {
+      final uri = Uri.parse('https://teamappai.netlify.app/#/matches/123');
+      service.handleUriForTest(uri, router);
+      verify(() => router.go('/matches/123')).called(1);
+    });
+
+    test('navigates to training route from mobile URI', () {
+      final uri = Uri.parse('teamapp://training/abc');
+      service.handleUriForTest(uri, router);
+      verify(() => router.go('/training/abc')).called(1);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- hook DeepLinkService into AppLinks stream and GoRouter
- parse URIs to open match or training screens
- add unit tests covering web and mobile link formats

## Testing
- `flutter test test/services/deep_link_service_test.dart` *(fails: command not found)*
- `dart test test/services/deep_link_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1665bbe38832a8fefa683c2a48a72