### PR TITLE
fix: align organization service fields and slug validation

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -107,7 +107,6 @@ linter:
     - avoid_double_and_int_checks
     - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
     - avoid_init_to_null
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters

--- a/lib/services/organization_service.dart
+++ b/lib/services/organization_service.dart
@@ -10,6 +10,8 @@ class OrganizationService {
 
   final SupabaseClient _supabase;
 
+  static const Set<String> _reservedSlugs = {'admin', 'api', 'app'};
+
   // Returns Supabase.instance.client when Supabase.initialize was called, or
   // falls back to a dummy client for unit-test contexts where full
   // initialization is undesirable.
@@ -35,8 +37,8 @@ class OrganizationService {
             'name': name,
             'slug': slug,
             'tier': tier.name,
-            'created_at': now,
-            'updated_at': now,
+            'createdAt': now,
+            'updatedAt': now,
           })
           .select()
           .single();
@@ -87,14 +89,14 @@ class OrganizationService {
             'name': org.name,
             'slug': org.slug,
             'tier': org.tier.name,
-            'logo_url': org.logoUrl,
-            'primary_color': org.primaryColor,
-            'secondary_color': org.secondaryColor,
+            'logoUrl': org.logoUrl,
+            'primaryColor': org.primaryColor,
+            'secondaryColor': org.secondaryColor,
             'settings': org.settings,
-            'subscription_status': org.subscriptionStatus,
-            'subscription_end_date':
+            'subscriptionStatus': org.subscriptionStatus,
+            'subscriptionEndDate':
                 org.subscriptionEndDate?.toIso8601String(),
-            'updated_at': DateTime.now().toUtc().toIso8601String(),
+            'updatedAt': DateTime.now().toUtc().toIso8601String(),
           })
           .eq('id', org.id)
           .select()
@@ -107,6 +109,8 @@ class OrganizationService {
   }
 
   Future<bool> isSlugAvailable(String slug) async {
+    final normalized = slug.toLowerCase();
+    if (_reservedSlugs.contains(normalized)) return false;
     try {
       final response = await _supabase
           .from('organizations')
@@ -121,18 +125,18 @@ class OrganizationService {
 
   Organization _mapOrganization(Map<String, dynamic> data) =>
       Organization.fromJson({
-        'id': data['id'],
-        'name': data['name'],
-        'slug': data['slug'],
-        'tier': data['tier'],
-        'logoUrl': data['logo_url'],
-        'primaryColor': data['primary_color'],
-        'secondaryColor': data['secondary_color'],
-        'settings': data['settings'],
-        'subscriptionStatus': data['subscription_status'],
-        'subscriptionEndDate': data['subscription_end_date'],
-        'createdAt': data['created_at'],
-        'updatedAt': data['updated_at'],
+        'id': data['id'] as String,
+        'name': data['name'] as String,
+        'slug': data['slug'] as String,
+        'tier': data['tier'] as String?,
+        'logoUrl': data['logoUrl'] as String?,
+        'primaryColor': data['primaryColor'] as String?,
+        'secondaryColor': data['secondaryColor'] as String?,
+        'settings': data['settings'] as Map<String, dynamic>?,
+        'subscriptionStatus': data['subscriptionStatus'] as String?,
+        'subscriptionEndDate': data['subscriptionEndDate'] as String?,
+        'createdAt': data['createdAt'] as String,
+        'updatedAt': data['updatedAt'] as String,
       });
 }
 

--- a/test/config/supabase_config_test.dart
+++ b/test/config/supabase_config_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: directives_ordering, avoid_implementing_value_types
+// ignore_for_file: directives_ordering
 
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: directives_ordering, avoid_implementing_value_types
+// ignore_for_file: directives_ordering
 
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';

--- a/test/services/demo_data_service_test.dart
+++ b/test/services/demo_data_service_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: directives_ordering, avoid_implementing_value_types
+// ignore_for_file: directives_ordering
 
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';

--- a/test/services/organization_service_test.dart
+++ b/test/services/organization_service_test.dart
@@ -42,8 +42,8 @@ void main() {
           'name': 'Test Club',
           'slug': 'test-club',
           'tier': 'basic',
-          'created_at': '2023-01-01T00:00:00Z',
-          'updated_at': '2023-01-01T00:00:00Z',
+          'createdAt': '2023-01-01T00:00:00Z',
+          'updatedAt': '2023-01-01T00:00:00Z',
           'settings': <String, dynamic>{},
         },
       );
@@ -69,8 +69,8 @@ void main() {
           'name': 'Test Club',
           'slug': 'test-club',
           'tier': 'basic',
-          'created_at': '2023-01-01T00:00:00Z',
-          'updated_at': '2023-01-01T00:00:00Z',
+          'createdAt': '2023-01-01T00:00:00Z',
+          'updatedAt': '2023-01-01T00:00:00Z',
           'settings': <String, dynamic>{},
         },
       );
@@ -93,8 +93,8 @@ void main() {
               'name': 'Test Club',
               'slug': 'test-club',
               'tier': 'basic',
-              'created_at': '2023-01-01T00:00:00Z',
-              'updated_at': '2023-01-01T00:00:00Z',
+              'createdAt': '2023-01-01T00:00:00Z',
+              'updatedAt': '2023-01-01T00:00:00Z',
               'settings': <String, dynamic>{},
             }
           }
@@ -128,8 +128,8 @@ void main() {
           'name': 'Test Club',
           'slug': 'test-club',
           'tier': 'basic',
-          'created_at': '2023-01-01T00:00:00Z',
-          'updated_at': '2023-01-02T00:00:00Z',
+          'createdAt': '2023-01-01T00:00:00Z',
+          'updatedAt': '2023-01-02T00:00:00Z',
           'settings': <String, dynamic>{},
         },
       );


### PR DESCRIPTION
## Summary
- use camelCase Supabase keys and add null-safe mapping in organization service
- restore reserved slug filtering for `isSlugAvailable`
- drop `avoid_implementing_value_types` lint and update tests

## Testing
- `dart format lib/services/organization_service.dart test/services/organization_service_test.dart test/services/demo_data_service_test.dart test/services/auth_service_test.dart test/config/supabase_config_test.dart` *(fails: command not found)*
- `dart test test/services/organization_service_test.dart test/services/demo_data_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16ffab340832abbfa250d077a173f